### PR TITLE
Feature/refactorings

### DIFF
--- a/royals_core/src/action.rs
+++ b/royals_core/src/action.rs
@@ -1,8 +1,0 @@
-use crate::Play;
-
-#[derive(Debug, PartialEq)]
-pub enum Action {
-    GiveUp,
-    Play(Play),
-}
-

--- a/royals_core/src/action.rs
+++ b/royals_core/src/action.rs
@@ -1,6 +1,4 @@
-use std::str::FromStr;
-
-use crate::{card::Card, player::Player, Play, PlayerId};
+use crate::Play;
 
 #[derive(Debug, PartialEq)]
 pub enum Action {
@@ -8,58 +6,3 @@ pub enum Action {
     Play(Play),
 }
 
-#[derive(Debug, PartialEq)]
-pub enum ConsoleAction {
-    Quit,
-    Rules,
-    CardEffects,
-    Card(Card),
-    Player(PlayerId),
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct ParseActionError;
-
-impl ConsoleAction {
-    pub fn info(&self, players: &[Player]) -> String {
-        match self {
-            ConsoleAction::Quit => "quit".to_string(),
-            ConsoleAction::Rules => "display rules".to_string(),
-            ConsoleAction::CardEffects => "display card effects".to_string(),
-            ConsoleAction::Card(c) => c.rule().to_string(),
-            ConsoleAction::Player(id) => players[*id].name.clone(),
-        }
-    }
-
-    pub fn cmd_str(&self) -> String {
-        match self {
-            ConsoleAction::Quit => "q".to_string(),
-            ConsoleAction::Rules => "r".to_string(),
-            ConsoleAction::CardEffects => "c".to_string(),
-            ConsoleAction::Card(c) => c.to_string(),
-            ConsoleAction::Player(id) => "".to_string() + &id.to_string(),
-        }
-    }
-}
-
-impl FromStr for ConsoleAction {
-    type Err = ParseActionError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "q" => Ok(ConsoleAction::Quit),
-            "r" => Ok(ConsoleAction::Rules),
-            "c" => Ok(ConsoleAction::CardEffects),
-            _ => {
-                if let Ok(p) = Card::from_str(s) {
-                    Ok(ConsoleAction::Card(p))
-                } else {
-                    if let Ok(p) = usize::from_str(s) {
-                        Ok(ConsoleAction::Player(p))
-                    } else {
-                        Err(ParseActionError)
-                    }
-                }
-            }
-        }
-    }
-}

--- a/royals_core/src/action.rs
+++ b/royals_core/src/action.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 
-use crate::{card::Card, Play, PlayerId, player::Player};
+use crate::{card::Card, player::Player, Play, PlayerId};
 
 #[derive(Debug, PartialEq)]
 pub enum Action {
-    Quit,
+    GiveUp,
     Play(Play),
 }
 

--- a/royals_core/src/console_player.rs
+++ b/royals_core/src/console_player.rs
@@ -6,10 +6,9 @@ use std::{
 use itertools::Itertools;
 
 use crate::{
-    action::Action,
     card::Card,
     event::Event,
-    play::Play,
+    play::{Action, Play},
     player::{Player, PlayerId, PlayerInterface},
 };
 

--- a/royals_core/src/console_player.rs
+++ b/royals_core/src/console_player.rs
@@ -6,7 +6,7 @@ use std::{
 use itertools::Itertools;
 
 use crate::{
-    action::{Action, ConsoleAction},
+    action::Action,
     card::Card,
     event::Event,
     play::Play,
@@ -23,12 +23,68 @@ When the card is played an action might be performed based on the type of card i
 At the beginning a card is put to the side, that is hidden an not used except for the special case, when the last card played is a Prince.
 If all opponents are protected one may choose to not do anything.";
 
+#[derive(Debug, PartialEq)]
+enum ConsoleAction {
+    Quit,
+    Rules,
+    CardEffects,
+    Card(Card),
+    Player(PlayerId),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ParseActionError;
+
+impl ConsoleAction {
+    fn info(&self, players: &[Player]) -> String {
+        match self {
+            ConsoleAction::Quit => "quit".to_string(),
+            ConsoleAction::Rules => "display rules".to_string(),
+            ConsoleAction::CardEffects => "display card effects".to_string(),
+            ConsoleAction::Card(c) => c.rule().to_string(),
+            ConsoleAction::Player(id) => players[*id].name.clone(),
+        }
+    }
+
+    fn cmd_str(&self) -> String {
+        match self {
+            ConsoleAction::Quit => "q".to_string(),
+            ConsoleAction::Rules => "r".to_string(),
+            ConsoleAction::CardEffects => "c".to_string(),
+            ConsoleAction::Card(c) => c.to_string(),
+            ConsoleAction::Player(id) => "".to_string() + &id.to_string(),
+        }
+    }
+}
+
+impl FromStr for ConsoleAction {
+    type Err = ParseActionError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "q" => Ok(ConsoleAction::Quit),
+            "r" => Ok(ConsoleAction::Rules),
+            "c" => Ok(ConsoleAction::CardEffects),
+            _ => {
+                if let Ok(p) = Card::from_str(s) {
+                    Ok(ConsoleAction::Card(p))
+                } else {
+                    if let Ok(p) = usize::from_str(s) {
+                        Ok(ConsoleAction::Player(p))
+                    } else {
+                        Err(ParseActionError)
+                    }
+                }
+            }
+        }
+    }
+}
+
 pub struct ConsolePlayer {
     pub id: PlayerId,
 }
 
 impl ConsolePlayer {
-    pub fn query_user(
+    fn query_user(
         &self,
         cmds: Vec<ConsoleAction>,
         prompt: &str,

--- a/royals_core/src/console_player.rs
+++ b/royals_core/src/console_player.rs
@@ -154,7 +154,7 @@ impl PlayerInterface for ConsolePlayer {
             let action =
                 self.prompt_card(&hand_cards, "Choose the card you want to play:", &players);
             match action {
-                ConsoleAction::Quit => return Action::Quit,
+                ConsoleAction::Quit => return Action::GiveUp,
                 ConsoleAction::Rules => println!("{}", RULES),
                 ConsoleAction::CardEffects => println!("{}", Card::rules()),
                 ConsoleAction::Card(c) => card = Some(c),
@@ -171,7 +171,7 @@ impl PlayerInterface for ConsolePlayer {
             while opponent.is_none() {
                 let action = self.prompt_opponent(&players);
                 match action {
-                    ConsoleAction::Quit => return Action::Quit,
+                    ConsoleAction::Quit => return Action::GiveUp,
                     ConsoleAction::Rules => println!("{}", RULES),
                     ConsoleAction::CardEffects => println!("{}", Card::rules()),
                     ConsoleAction::Player(c) => opponent = Some(c),
@@ -197,7 +197,7 @@ impl PlayerInterface for ConsolePlayer {
                     &players,
                 );
                 match action {
-                    ConsoleAction::Quit => return Action::Quit,
+                    ConsoleAction::Quit => return Action::GiveUp,
                     ConsoleAction::Rules => println!("{}", RULES),
                     ConsoleAction::CardEffects => println!("{}", Card::rules()),
                     ConsoleAction::Card(c) => guess = Some(c),

--- a/royals_core/src/console_player.rs
+++ b/royals_core/src/console_player.rs
@@ -195,7 +195,14 @@ impl PlayerInterface for ConsolePlayer {
         }
     }
 
-    fn obtain_action(&self, hand_cards: &[Card], players: &[String], game_log: &[Event], all_protected:bool, active_players:&[PlayerId]) -> Action {
+    fn obtain_action(
+        &self,
+        hand_cards: &[Card],
+        players: &[String],
+        game_log: &[Event],
+        all_protected: bool,
+        active_players: &[PlayerId],
+    ) -> Action {
         self.notify(game_log, players);
 
         let mut card = None;

--- a/royals_core/src/console_player.rs
+++ b/royals_core/src/console_player.rs
@@ -145,7 +145,7 @@ impl ConsolePlayer {
 
     fn print_event(&self, event: &Event, players: &[Player]) {
         match &event {
-            Event::Play(pl, p) => println!("~ PLay: {} played {}", players[*pl].name, p.info()),
+            Event::Play(pl, p) => println!("~ Play: {} played {}", players[*pl].name, p.info()),
             Event::DropOut(pl) => println!("~ DropOut: {}", players[*pl].name),
             Event::Fold(pl, c, reason) => println!(
                 "~ Fold: {} folded {}, because {}",

--- a/royals_core/src/game_state.rs
+++ b/royals_core/src/game_state.rs
@@ -5,7 +5,7 @@ use crate::{
     console_player::ConsolePlayer,
     event::{Event, EventEntry, EventVisibility},
     play::{Action, Play},
-    player::{PlayerInterface, PlayerId},
+    player::{PlayerId, PlayerInterface},
     random_playing_computer::RandomPlayingComputer,
 };
 
@@ -15,12 +15,9 @@ struct Player {
 
 impl Player {
     pub fn new(interface: Box<dyn PlayerInterface>) -> Self {
-        Self {
-            interface,
-        }
+        Self { interface }
     }
 }
-
 
 pub struct GameState {
     deck: Vec<Card>,
@@ -38,18 +35,24 @@ impl GameState {
         let mut players = vec![];
         let mut player_names = vec![];
 
-        player_names.push( "You");
-        player_names.push( "Computer Alpha");
-        player_names.push( "Computer Bravo");
-        player_names.push( "Computer Charlie");
+        player_names.push("You");
+        player_names.push("Computer Alpha");
+        player_names.push("Computer Bravo");
+        player_names.push("Computer Charlie");
         let player_names = player_names.iter().map(|x| x.to_string()).collect();
-        players.push(Player::new( Box::new(ConsolePlayer { id: players.len() }),));
-        players.push(Player::new( Box::new(RandomPlayingComputer { id: players.len() }),));
-        players.push(Player::new( Box::new(RandomPlayingComputer { id: players.len() }),));
-        players.push(Player::new( Box::new(RandomPlayingComputer { id: players.len() }),));
+        players.push(Player::new(Box::new(ConsolePlayer { id: players.len() })));
+        players.push(Player::new(Box::new(RandomPlayingComputer {
+            id: players.len(),
+        })));
+        players.push(Player::new(Box::new(RandomPlayingComputer {
+            id: players.len(),
+        })));
+        players.push(Player::new(Box::new(RandomPlayingComputer {
+            id: players.len(),
+        })));
         //state.players.shuffle(&mut rand::thread_rng()); todo
         let player_protected = vec![false, false, false, false];
-        let hand_cards:Vec<Vec<Card>> = vec![vec![], vec![], vec![], vec![]];
+        let hand_cards: Vec<Vec<Card>> = vec![vec![], vec![], vec![], vec![]];
 
         let mut state = GameState {
             deck: vec![
@@ -99,7 +102,7 @@ impl GameState {
                 &self.player_names,
                 &self.filter_event(),
                 self.all_protected(),
-                &self.active_players()
+                &self.active_players(),
             );
 
             match user_action {
@@ -194,7 +197,8 @@ impl GameState {
 
     fn active_players(&self) -> Vec<PlayerId> {
         self.hand_cards
-            .iter().enumerate()
+            .iter()
+            .enumerate()
             .filter(|(_, hc)| !hc.is_empty())
             .map(|(i, _)| i)
             .collect()
@@ -213,8 +217,7 @@ impl GameState {
         if play.card == Card::Princess {
             return false;
         }
-        if self.hand_cards[self.players_turn].contains(&Card::Contess)
-        {
+        if self.hand_cards[self.players_turn].contains(&Card::Contess) {
             if play.card == Card::Prince || play.card == Card::King {
                 return false;
             }
@@ -236,10 +239,9 @@ impl GameState {
     }
 
     fn all_protected(&self) -> bool {
-        self.players
-            .iter()
-            .enumerate()
-            .all(|(i, _)| self.hand_cards[i].is_empty() || self.player_protected[i] || i == self.players_turn)
+        self.players.iter().enumerate().all(|(i, _)| {
+            self.hand_cards[i].is_empty() || self.player_protected[i] || i == self.players_turn
+        })
     }
 
     fn handle_play(&mut self, p: Play) {

--- a/royals_core/src/game_state.rs
+++ b/royals_core/src/game_state.rs
@@ -79,9 +79,8 @@ impl GameState {
             if ok {
                 self.pick_up_card(self.players_turn);
             }
-            let player_cards = &self.players[self.players_turn].hand_cards;
             let user_action = self.players[self.players_turn].interface.obtain_action(
-                &player_cards,
+                &self.players[self.players_turn].hand_cards,
                 &self.players,
                 &self.filter_event(),
             );
@@ -185,7 +184,7 @@ impl GameState {
 
     fn next_player_turn(&mut self) {
         self.players_turn = (self.players_turn + 1) % self.players.len();
-        while self.players[self.players_turn].hand_cards.len() == 0 {
+        while self.players[self.players_turn].hand_cards.is_empty() {
             self.players_turn = (self.players_turn + 1) % self.players.len();
         }
         // last card is ussually not used
@@ -196,8 +195,7 @@ impl GameState {
         if play.card == Card::Princess {
             return false;
         }
-        if self.players[self.players_turn].hand_cards[0] == Card::Contess
-            || self.players[self.players_turn].hand_cards[1] == Card::Contess
+        if self.players[self.players_turn].hand_cards.contains(&Card::Contess)
         {
             if play.card == Card::Prince || play.card == Card::King {
                 return false;
@@ -308,7 +306,7 @@ impl GameState {
             Card::Contess => {}
             Card::Princess => self.drop_player(
                 self.players_turn,
-                "playing the princess is illegal".to_string(),
+                "playing the princess is equivalent to giving up".to_string(),
             ),
         }
     }

--- a/royals_core/src/game_state.rs
+++ b/royals_core/src/game_state.rs
@@ -1,11 +1,10 @@
 use rand::seq::SliceRandom;
 
 use crate::{
-    action::Action,
     card::Card,
     console_player::ConsolePlayer,
     event::{Event, EventEntry, EventVisibility},
-    play::Play,
+    play::{Action, Play},
     player::{Player, PlayerId},
     random_playing_computer::RandomPlayingComputer,
 };

--- a/royals_core/src/lib.rs
+++ b/royals_core/src/lib.rs
@@ -1,7 +1,6 @@
 use event::Event;
 use game_state::GameState;
 use play::Play;
-use player::PlayerId;
 
 mod action;
 mod card;

--- a/royals_core/src/lib.rs
+++ b/royals_core/src/lib.rs
@@ -1,8 +1,6 @@
 use event::Event;
 use game_state::GameState;
-use play::Play;
 
-mod action;
 mod card;
 mod console_player;
 mod event;

--- a/royals_core/src/play.rs
+++ b/royals_core/src/play.rs
@@ -39,3 +39,9 @@ impl FromStr for Play {
         }
     }
 }
+
+#[derive(Debug, PartialEq)]
+pub enum Action {
+    GiveUp,
+    Play(Play),
+}

--- a/royals_core/src/player.rs
+++ b/royals_core/src/player.rs
@@ -2,25 +2,7 @@ use crate::{card::Card, play::Action, Event};
 
 pub type PlayerId = usize;
 
-pub struct Player {
-    pub name: String,
-    pub interface: Box<dyn PlayerInterface>,
-    pub hand_cards: Vec<Card>,
-    pub protected: bool,
-}
-
-impl Player {
-    pub fn new(name: &str, interface: Box<dyn PlayerInterface>) -> Self {
-        Self {
-            name: name.to_string(),
-            interface,
-            hand_cards: vec![],
-            protected: false,
-        }
-    }
-}
-
 pub trait PlayerInterface {
-    fn notify(&self, game_log: &[Event], players: &[Player]);
-    fn obtain_action(&self, hand_cards: &[Card], players: &[Player], game_log: &[Event]) -> Action;
+    fn notify(&self, game_log: &[Event], players: &[String]);
+    fn obtain_action(&self, hand_cards: &[Card], players: &[String], game_log: &[Event], all_protected:bool, active_players: &[PlayerId]) -> Action;
 }

--- a/royals_core/src/player.rs
+++ b/royals_core/src/player.rs
@@ -1,4 +1,4 @@
-use crate::{action::Action, card::Card, Event};
+use crate::{card::Card, play::Action, Event};
 
 pub type PlayerId = usize;
 

--- a/royals_core/src/player.rs
+++ b/royals_core/src/player.rs
@@ -4,5 +4,12 @@ pub type PlayerId = usize;
 
 pub trait PlayerInterface {
     fn notify(&self, game_log: &[Event], players: &[String]);
-    fn obtain_action(&self, hand_cards: &[Card], players: &[String], game_log: &[Event], all_protected:bool, active_players: &[PlayerId]) -> Action;
+    fn obtain_action(
+        &self,
+        hand_cards: &[Card],
+        players: &[String],
+        game_log: &[Event],
+        all_protected: bool,
+        active_players: &[PlayerId],
+    ) -> Action;
 }

--- a/royals_core/src/random_playing_computer.rs
+++ b/royals_core/src/random_playing_computer.rs
@@ -21,7 +21,6 @@ impl PlayerInterface for RandomPlayingComputer {
         _game_log: &[Event],
         all_protected: bool,
         _active_players: &[PlayerId],
-
     ) -> Action {
         let mut hand = hand_cards.to_vec();
         hand.shuffle(&mut rand::thread_rng());

--- a/royals_core/src/random_playing_computer.rs
+++ b/royals_core/src/random_playing_computer.rs
@@ -4,7 +4,7 @@ use crate::{
     card::Card,
     event::Event,
     play::{Action, Play},
-    player::{Player, PlayerId, PlayerInterface},
+    player::{PlayerId, PlayerInterface},
 };
 
 pub struct RandomPlayingComputer {
@@ -12,22 +12,19 @@ pub struct RandomPlayingComputer {
 }
 
 impl PlayerInterface for RandomPlayingComputer {
-    fn notify(&self, _game_log: &[Event], _players: &[Player]) {}
+    fn notify(&self, _game_log: &[Event], _players: &[String]) {}
 
     fn obtain_action(
         &self,
         hand_cards: &[Card],
-        players: &[Player],
+        players: &[String],
         _game_log: &[Event],
+        all_protected: bool,
+        _active_players: &[PlayerId],
+
     ) -> Action {
         let mut hand = hand_cards.to_vec();
         hand.shuffle(&mut rand::thread_rng());
-        let mut all_protected = true;
-        for (ind, p) in players.iter().enumerate() {
-            if !p.hand_cards.is_empty() && !p.protected && ind != self.id {
-                all_protected = false;
-            }
-        }
         let mut play = Play {
             card: hand[0],
             opponent: None,
@@ -51,7 +48,7 @@ impl PlayerInterface for RandomPlayingComputer {
         if let Action::Play(p) = &mut action {
             if p.card.needs_opponent() && !all_protected {
                 let chosen = players.choose(&mut rand::thread_rng()).unwrap();
-                let index = players.iter().position(|x| x.name == chosen.name).unwrap();
+                let index = players.iter().position(|x| x == chosen).unwrap();
                 p.opponent = Some(index);
             }
             if p.card.needs_guess() && !all_protected {

--- a/royals_core/src/random_playing_computer.rs
+++ b/royals_core/src/random_playing_computer.rs
@@ -1,10 +1,9 @@
 use rand::seq::SliceRandom;
 
 use crate::{
-    action::Action,
     card::Card,
     event::Event,
-    play::Play,
+    play::{Action, Play},
     player::{Player, PlayerId, PlayerInterface},
 };
 


### PR DESCRIPTION
- rename `Quit` to `Give up` and better handling
- Move `Console Action` to `Console Player`
- move `Action` to `Play` (file was almost empty)
- Player interface now gets other players names, list of active players, and `all protected`. Does not need to see hand cards of other players. This makes the function take to many params. Refactor later.
- handle `protected` and `hand_cards` separately in `game_state`