### PR TITLE
Immutable gamestate

### DIFF
--- a/royals_core/src/card.rs
+++ b/royals_core/src/card.rs
@@ -64,6 +64,27 @@ impl Card {
         )
     }
 
+    pub fn deck() -> [Card; 16] {
+        [
+            Card::Guard,
+            Card::Guard,
+            Card::Guard,
+            Card::Guard,
+            Card::Guard,
+            Card::Priest,
+            Card::Priest,
+            Card::Baron,
+            Card::Baron,
+            Card::Maid,
+            Card::Maid,
+            Card::Prince,
+            Card::Prince,
+            Card::King,
+            Card::Countess,
+            Card::Princess,
+        ]
+    }
+
     fn value(&self) -> u8 {
         *self as u8 + 1
     }

--- a/royals_core/src/game_lobby.rs
+++ b/royals_core/src/game_lobby.rs
@@ -77,9 +77,9 @@ impl GameLobby {
 
             state.handle_action(chosen_action, &deck, &mut game_log);
 
-            for p in &self.players {
+            for (i, p) in self.players.iter().enumerate() {
                 p.notify(
-                    &GameLobby::filter_event(&game_log, None),
+                    &GameLobby::filter_event(&game_log, Some(i)),
                     &self.player_names(),
                 );
             }

--- a/royals_core/src/game_lobby.rs
+++ b/royals_core/src/game_lobby.rs
@@ -1,12 +1,4 @@
-use crate::{
-    card::Card,
-    event::Event,
-    event::EventEntry,
-    event::EventVisibility,
-    game_state::GameState,
-    play::ActionId,
-    player::{Player, PlayerId},
-};
+use crate::{card::Card, event::EventEntry, game_state::GameState, play::ActionId, player::Player};
 
 use rand::seq::SliceRandom;
 
@@ -32,25 +24,6 @@ impl GameLobby {
         self.players.iter().map(|p| p.name()).collect::<Vec<_>>()
     }
 
-    fn filter_event(log: &[EventEntry], visible_to: Option<PlayerId>) -> Vec<Event> {
-        log.iter()
-            .map(|e| match e.visibility {
-                EventVisibility::Public => e.event.clone(),
-                EventVisibility::Private(player) => {
-                    if visible_to.is_none() || player == visible_to.unwrap() {
-                        e.event.clone()
-                    } else {
-                        match e.event {
-                            Event::PickUp(p, _, s) => Event::PickUp(p, None, s),
-                            Event::LearnedCard(p, _) => Event::LearnedCard(p, None),
-                            _ => e.event.clone(),
-                        }
-                    }
-                }
-            })
-            .collect()
-    }
-
     pub fn play_round(&mut self) {
         let mut game_log: Vec<EventEntry> = vec![];
 
@@ -71,7 +44,7 @@ impl GameLobby {
 
             let chosen_action: ActionId = self.players[players_turn.unwrap()].obtain_action(
                 &self.player_names(),
-                &GameLobby::filter_event(&game_log, players_turn),
+                &GameState::filter_event(&game_log, players_turn),
                 &actions,
             );
 
@@ -79,7 +52,7 @@ impl GameLobby {
 
             for (i, p) in self.players.iter().enumerate() {
                 p.notify(
-                    &GameLobby::filter_event(&game_log, Some(i)),
+                    &GameState::filter_event(&game_log, Some(i)),
                     &self.player_names(),
                 );
             }

--- a/royals_core/src/game_lobby.rs
+++ b/royals_core/src/game_lobby.rs
@@ -75,7 +75,7 @@ impl GameLobby {
                 &actions,
             );
 
-            state.handle_action(chosen_action, &deck, &mut game_log);
+            state.handle_action(chosen_action, &mut game_log);
 
             for (i, p) in self.players.iter().enumerate() {
                 p.notify(

--- a/royals_core/src/game_lobby.rs
+++ b/royals_core/src/game_lobby.rs
@@ -1,0 +1,166 @@
+use crate::{
+    card::Card,
+    event::Event,
+    event::EventEntry,
+    event::EventVisibility,
+    game_state::GameState,
+    play::Action,
+    player::{Player, PlayerId},
+};
+
+use rand::seq::SliceRandom;
+
+pub struct GameLobby {
+    players: Vec<Box<dyn Player>>,
+}
+
+impl GameLobby {
+    pub fn new() -> Self {
+        GameLobby { players: vec![] }
+    }
+
+    pub fn add_player<C, T>(&mut self, player_constructor: C)
+    where
+        C: FnOnce() -> T,
+        T: Player + 'static,
+    {
+        let player = player_constructor();
+        self.players.push(Box::new(player));
+    }
+
+    pub fn player_names(&self) -> Vec<&String> {
+        self.players.iter().map(|p| p.name()).collect::<Vec<_>>()
+    }
+
+    pub fn play_round(&mut self) {
+        let mut deck_to_shuffle = Card::deck();
+        deck_to_shuffle.shuffle(&mut rand::thread_rng());
+        let deck = deck_to_shuffle;
+        self.players.shuffle(&mut rand::thread_rng());
+        let mut state = GameState::new(self.players.len());
+
+        for i in 0..self.players.len() {
+            state.pick_up_card(i, &deck);
+        }
+
+        let mut ok = true;
+        let mut running = true;
+
+        while running {
+            if ok {
+                state.pick_up_card(state.players_turn, &deck);
+            }
+            let actions = state.valid_actions();
+            let chosen_action_index = self.players[state.players_turn].obtain_action(
+                &self.player_names(),
+                &state.filter_event(),
+                &actions,
+            );
+            ok = chosen_action_index < actions.len();
+            if ok {
+                match &actions[chosen_action_index] {
+                    Action::GiveUp => {
+                        state.drop_player(state.players_turn, "Player gave up".to_string());
+                        running = state.next_player_turn(&deck);
+                    }
+                    Action::Play(p) => {
+                        if ok {
+                            state.handle_play(p, &deck);
+                            running = state.next_player_turn(&deck);
+                        }
+                    }
+                }
+            }
+        }
+        for mut p in &mut state.game_log {
+            p.visibility = EventVisibility::Public;
+        }
+        let mut best_players: Vec<PlayerId> = vec![];
+        let mut best_card: Option<Card> = None;
+        for (i, p) in state.players.iter().enumerate() {
+            if let Some(player_card) = p.hand().get(0) {
+                state.game_log.push(EventEntry {
+                    visibility: EventVisibility::Public,
+                    event: Event::Fold(i, player_card.clone(), "game is finished".to_string()),
+                });
+                if let Some(card) = best_card {
+                    if card < *player_card {
+                        best_players = vec![i];
+                        best_card = Some(player_card.clone());
+                    } else if card == *player_card {
+                        best_players.push(i);
+                    }
+                } else {
+                    best_players = vec![i];
+                    best_card = Some(player_card.clone());
+                }
+            }
+        }
+        state.game_log.push(EventEntry {
+            visibility: EventVisibility::Public,
+            event: Event::Winner(best_players),
+        });
+        for p in &self.players {
+            p.notify(&state.filter_event(), &self.player_names());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        event::Event,
+        game_lobby::GameLobby,
+        play::Action,
+        player::{Player, PlayerData},
+    };
+
+    #[test]
+    fn player_names_should_return_list_of_names() {
+        let lobby = GameLobby {
+            players: vec![
+                Box::new(TestPlayer::new("Foo")),
+                Box::new(TestPlayer::new("Bar")),
+            ],
+        };
+
+        assert_eq!(lobby.player_names(), vec!["Foo", "Bar"]);
+    }
+
+    // Infra ----------------------------------------------------------------
+
+    pub struct TestPlayer {
+        pub data: PlayerData,
+    }
+
+    impl TestPlayer {
+        pub fn new(name: &str) -> Self {
+            TestPlayer {
+                data: PlayerData::new(name.to_string()),
+            }
+        }
+    }
+
+    impl Player for TestPlayer {
+        fn data(&self) -> &PlayerData {
+            &self.data
+        }
+
+        fn data_mut(&mut self) -> &mut PlayerData {
+            &mut self.data
+        }
+
+        fn notify(&self, _game_log: &[Event], _players: &[&String]) {
+            todo!()
+        }
+
+        fn obtain_action(
+            &self,
+            _players: &[&String],
+            _game_log: &[Event],
+            _actions: &[Action],
+        ) -> usize {
+            todo!()
+        }
+    }
+}

--- a/royals_core/src/game_logic.rs
+++ b/royals_core/src/game_logic.rs
@@ -43,11 +43,15 @@ impl GameState<'_> {
     }
 
     pub fn pick_up_card(&mut self, player_id: PlayerId, log: &mut Vec<EventEntry>) {
-        let next_card = self.deck[self.deck_head];
-        self.deck_head += 1;
+        let next_card = self.deck[self.played_card_count];
+        self.played_card_count += 1;
         log.push(EventEntry {
             visibility: EventVisibility::Private(player_id),
-            event: Event::PickUp(player_id, Some(next_card), self.deck.len() - self.deck_head),
+            event: Event::PickUp(
+                player_id,
+                Some(next_card),
+                self.deck.len() - self.played_card_count,
+            ),
         });
         self.players[player_id].hand_mut().push(next_card);
     }

--- a/royals_core/src/game_logic.rs
+++ b/royals_core/src/game_logic.rs
@@ -1,166 +1,129 @@
-use itertools::Itertools;
-
 use crate::{
     card::Card,
     event::{Event, EventEntry, EventVisibility},
     game_state::GameState,
-    play::{Action, Play},
+    play::{Action, ActionId, Play},
     player::PlayerId,
     utils::VecExtensions,
 };
 
-impl GameState {
-    pub fn valid_actions(&self) -> Vec<Action> {
-        let mut actions = vec![Action::GiveUp];
-        let mut first_card: Option<Card> = None;
-
-        for card in self.players[self.players_turn].hand() {
-            // avoid dublicate entries
-            if first_card.is_none() {
-                first_card = Some(*card);
-            } else if first_card.unwrap() == *card {
-                break;
-            }
-
-            actions.push(Action::Play(Play {
-                card: *card,
-                opponent: None,
-                guess: None,
-            }));
-            for opponent in self.other_active_players() {
-                actions.push(Action::Play(Play {
-                    card: *card,
-                    opponent: Some(opponent),
-                    guess: None,
-                }));
-                for guess in Card::guessable() {
-                    actions.push(Action::Play(Play {
-                        card: *card,
-                        opponent: Some(opponent),
-                        guess: Some(*guess),
-                    }));
+impl GameState<'_> {
+    pub fn handle_action(&mut self, action: ActionId, log: &mut Vec<EventEntry>) {
+        let (_, actions) = self.valid_actions();
+        if action < actions.len() {
+            match &actions[action] {
+                Action::GiveUp => {
+                    self.drop_player(self.players_turn, "Player gave up", log);
+                }
+                Action::Play(p) => {
+                    self.handle_play(p, log);
                 }
             }
+            self.next_player_turn(log);
         }
-        actions
-            .into_iter()
-            .filter(|a| self.is_valid(a))
-            .collect_vec()
     }
 
-    pub fn filter_event(&self) -> Vec<Event> {
-        let mut events = vec![];
-        for e in &self.game_log {
-            match e.visibility {
-                EventVisibility::Public => events.push(e.event.clone()),
+    pub fn filter_event(log: &[EventEntry], visible_to: Option<PlayerId>) -> Vec<Event> {
+        log.iter()
+            .map(|e| match e.visibility {
+                EventVisibility::Public => e.event.clone(),
                 EventVisibility::Private(player) => {
-                    if player == self.players_turn {
-                        events.push(e.event.clone())
+                    if visible_to.is_none() || player == visible_to.unwrap() {
+                        e.event.clone()
                     } else {
                         match e.event {
-                            Event::PickUp(p, _, s) => events.push(Event::PickUp(p, None, s)),
-                            Event::LearnedCard(p, _) => events.push(Event::LearnedCard(p, None)),
-                            _ => events.push(e.event.clone()),
+                            Event::PickUp(p, _, s) => Event::PickUp(p, None, s),
+                            Event::LearnedCard(p, _) => Event::LearnedCard(p, None),
+                            _ => e.event.clone(),
                         }
                     }
                 }
-            }
-        }
-        events
+            })
+            .collect()
     }
 
-    pub fn pick_up_card(&mut self, player_id: PlayerId, deck: &[Card]) {
-        let next_card = deck[self.deck_head];
+    pub fn pick_up_card(&mut self, player_id: PlayerId, log: &mut Vec<EventEntry>) {
+        let next_card = self.deck[self.deck_head];
         self.deck_head += 1;
-        self.game_log.push(EventEntry {
+        log.push(EventEntry {
             visibility: EventVisibility::Private(player_id),
-            event: Event::PickUp(player_id, Some(next_card), deck.len() - self.deck_head),
+            event: Event::PickUp(player_id, Some(next_card), self.deck.len() - self.deck_head),
         });
         self.players[player_id].hand_mut().push(next_card);
     }
 
-    pub fn drop_player(&mut self, player_id: PlayerId, reason: String) {
+    pub fn drop_player(&mut self, player_id: PlayerId, reason: &str, log: &mut Vec<EventEntry>) {
         while let Some(op_card) = self.players[player_id].hand_mut().pop() {
-            self.game_log.push(EventEntry {
+            log.push(EventEntry {
                 visibility: EventVisibility::Public,
-                event: Event::Fold(player_id, op_card, reason.clone()),
+                event: Event::Fold(player_id, op_card, reason.to_string()),
             });
         }
-        self.game_log.push(EventEntry {
+        log.push(EventEntry {
             visibility: EventVisibility::Public,
             event: Event::DropOut(player_id),
         });
     }
 
-    pub fn next_player_turn(&mut self, deck: &[Card]) -> bool {
+    pub fn next_player_turn(&mut self, log: &mut Vec<EventEntry>) {
         self.players_turn = (self.players_turn + 1) % self.players.len();
         while !self.players[self.players_turn].is_active() {
             self.players_turn = (self.players_turn + 1) % self.players.len();
         }
-        // last card is ussually not used
-        deck.len() - self.deck_head > 1 && self.active_players().len() > 1
-    }
-
-    fn is_valid(&self, action: &Action) -> bool {
-        match action {
-            Action::GiveUp => true,
-            Action::Play(play) => {
-                if !self.players[self.players_turn].hand().contains(&play.card) {
-                    return false;
-                }
-                if self.players[self.players_turn]
-                    .hand()
-                    .contains(&Card::Countess)
-                    && (play.card == Card::Prince || play.card == Card::King)
-                {
-                    return false;
-                }
-                if !play.card.needs_opponent() {
-                    if play.opponent.is_some() {
-                        return false;
-                    }
-                } else if !self.all_protected() && play.opponent.is_none() {
-                    return false;
-                }
-
-                if !play.card.needs_guess() {
-                    if play.guess.is_some() {
-                        return false;
-                    }
-                } else if !self.all_protected() && play.guess.is_none() {
-                    return false;
-                }
-
-                if let Some(op) = play.opponent {
-                    if op == self.players_turn {
-                        return false;
-                    }
-                    if op >= self.players.len() {
-                        return false;
-                    }
-                    if !self.players[op].is_active() {
-                        return false;
-                    }
-                }
-                true
-            }
+        if !self.game_over() {
+            self.pick_up_card(self.players_turn, log);
+        } else {
+            self.wrap_up_round(log);
         }
     }
 
-    pub fn handle_play(&mut self, p: &Play, deck: &[Card]) {
+    pub fn wrap_up_round(&mut self, log: &mut Vec<EventEntry>) {
+        let mut best_players: Vec<PlayerId> = vec![];
+        let mut best_card: Option<Card> = None;
+        for (i, p) in self.players.iter().enumerate() {
+            if let Some(player_card) = p.hand().get(0) {
+                log.push(EventEntry {
+                    visibility: EventVisibility::Public,
+                    event: Event::Fold(i, *player_card, "game is finished".to_string()),
+                });
+                if let Some(card) = best_card {
+                    if card < *player_card {
+                        best_players = vec![i];
+                        best_card = Some(*player_card);
+                    } else if card == *player_card {
+                        best_players.push(i);
+                    }
+                } else {
+                    best_players = vec![i];
+                    best_card = Some(*player_card);
+                }
+            }
+        }
+
+        log.push(EventEntry {
+            visibility: EventVisibility::Public,
+            event: Event::Winner(best_players),
+        });
+
+        for e in log {
+            e.visibility = EventVisibility::Public;
+        }
+    }
+
+    pub fn handle_play(&mut self, p: &Play, log: &mut Vec<EventEntry>) {
         let card = self.players[self.players_turn]
             .hand_mut()
             .remove_first_where(|&card| card == p.card)
             .unwrap();
 
-        self.game_log.push(EventEntry {
+        log.push(EventEntry {
             visibility: EventVisibility::Public,
             event: Event::Play(self.players_turn, p.clone()),
         });
         if let Some(opponent) = p.opponent {
             // do not attack protected player
             if self.players[opponent].protected() && !self.all_protected() {
-                self.drop_player(self.players_turn, "attacked a protected player".to_string());
+                self.drop_player(self.players_turn, "attacked a protected player", log);
                 return;
             }
         }
@@ -170,13 +133,13 @@ impl GameState {
                 if let Some(op) = p.opponent {
                     let g = p.guess.unwrap();
                     if self.players[op].hand()[0] == g {
-                        self.drop_player(op, "opponent guessed the hand card".to_string())
+                        self.drop_player(op, "opponent guessed the hand card", log)
                     }
                 }
             }
             Card::Priest => {
                 if let Some(op) = p.opponent {
-                    self.game_log.push(EventEntry {
+                    log.push(EventEntry {
                         visibility: EventVisibility::Private(self.players_turn),
                         event: Event::LearnedCard(op, Some(self.players[op].hand()[0])),
                     });
@@ -187,12 +150,9 @@ impl GameState {
                     let op_card = self.players[op].hand()[0];
                     let player_card = self.players[self.players_turn].hand()[0];
                     if op_card < player_card {
-                        self.drop_player(op, "smaller card then opponent".to_string());
+                        self.drop_player(op, "smaller card then opponent", log);
                     } else if player_card < op_card {
-                        self.drop_player(
-                            self.players_turn,
-                            "smaller card then opponent".to_string(),
-                        );
+                        self.drop_player(self.players_turn, "smaller card then opponent", log);
                     }
                 }
             }
@@ -202,10 +162,10 @@ impl GameState {
             Card::Prince => {
                 if let Some(op) = p.opponent {
                     if self.players[op].hand()[0] == Card::Princess {
-                        self.drop_player(op, "forced to play the princess".to_string());
+                        self.drop_player(op, "forced to play the princess", log);
                     } else {
                         let folded = self.players[op].hand_mut().pop().unwrap();
-                        self.game_log.push(EventEntry {
+                        log.push(EventEntry {
                             visibility: EventVisibility::Public,
                             event: Event::Fold(
                                 op,
@@ -213,7 +173,7 @@ impl GameState {
                                 "opponent has played prince to force it".to_string(),
                             ),
                         });
-                        self.pick_up_card(op, deck);
+                        self.pick_up_card(op, log);
                     }
                 }
             }
@@ -228,7 +188,8 @@ impl GameState {
             Card::Countess => {}
             Card::Princess => self.drop_player(
                 self.players_turn,
-                "playing the princess is equivalent to giving up".to_string(),
+                "playing the princess is equivalent to giving up",
+                log,
             ),
         }
     }

--- a/royals_core/src/game_state.rs
+++ b/royals_core/src/game_state.rs
@@ -4,13 +4,12 @@ use strum::IntoEnumIterator;
 
 use crate::{
     card::Card,
-    event::{Event, EventEntry, EventVisibility},
-    play::{Action, ActionId, Play},
+    event::EventEntry,
+    play::{Action, Play},
     player::PlayerId,
-    utils::VecExtensions,
 };
 
-struct PlayerState {
+pub struct PlayerState {
     protected: bool,
     hand: Vec<Card>,
 }
@@ -22,32 +21,32 @@ impl PlayerState {
             hand: vec![],
         }
     }
-    fn protected(&self) -> bool {
-        self.protected.clone()
+    pub fn protected(&self) -> bool {
+        self.protected
     }
 
-    fn set_protected(&mut self, value: bool) {
+    pub fn set_protected(&mut self, value: bool) {
         self.protected = value;
     }
 
-    fn hand(&self) -> &Vec<Card> {
+    pub fn hand(&self) -> &Vec<Card> {
         &self.hand
     }
 
-    fn hand_mut(&mut self) -> &mut Vec<Card> {
+    pub fn hand_mut(&mut self) -> &mut Vec<Card> {
         &mut self.hand
     }
 
-    fn is_active(&self) -> bool {
+    pub fn is_active(&self) -> bool {
         !&self.hand().is_empty()
     }
 }
 
 pub struct GameState<'a> {
-    players: Vec<PlayerState>,
-    deck_head: usize,
-    players_turn: PlayerId,
-    deck: &'a [Card],
+    pub players: Vec<PlayerState>,
+    pub deck_head: usize,
+    pub players_turn: PlayerId,
+    pub deck: &'a [Card],
 }
 
 impl<'a> GameState<'a> {
@@ -65,22 +64,6 @@ impl<'a> GameState<'a> {
         state.pick_up_card(state.players_turn, log);
         state
     }
-
-    pub fn handle_action(&mut self, action: ActionId, log: &mut Vec<EventEntry>) {
-        let (_, actions) = self.valid_actions();
-        if action < actions.len() {
-            match &actions[action] {
-                Action::GiveUp => {
-                    self.drop_player(self.players_turn, "Player gave up", log);
-                }
-                Action::Play(p) => {
-                    self.handle_play(p, log);
-                }
-            }
-            self.next_player_turn(log);
-        }
-    }
-
     pub fn valid_actions(&self) -> (Option<PlayerId>, Vec<Action>) {
         let actions: Vec<Action> = once(Action::GiveUp)
             .chain(self.possible_actions())
@@ -96,13 +79,13 @@ impl<'a> GameState<'a> {
         )
     }
 
-    fn possible_actions(&self) -> Vec<Action> {
+    pub fn possible_actions(&self) -> Vec<Action> {
         // todo is there an alternative way to also iterate over None
         let others = self.other_active_players();
-        let mut optional_players = others.iter().map(|p| Some(p.clone())).collect_vec();
+        let mut optional_players = others.iter().map(|p| Some(*p)).collect_vec();
         optional_players.push(None);
 
-        let mut optional_card = Card::iter().map(|c| Some(c)).collect_vec();
+        let mut optional_card = Card::iter().map(Some).collect_vec();
         optional_card.push(None);
 
         iproduct!(Card::iter(), optional_players.iter(), optional_card.iter())
@@ -116,7 +99,7 @@ impl<'a> GameState<'a> {
             .collect_vec()
     }
 
-    fn is_valid(&self, action: &Action) -> bool {
+    pub fn is_valid(&self, action: &Action) -> bool {
         if self.game_over() {
             return false;
         }
@@ -129,29 +112,24 @@ impl<'a> GameState<'a> {
                 if self.players[self.players_turn]
                     .hand()
                     .contains(&Card::Countess)
+                    && (play.card == Card::Prince || play.card == Card::King)
                 {
-                    if play.card == Card::Prince || play.card == Card::King {
-                        return false;
-                    }
+                    return false;
                 }
                 if !play.card.needs_opponent() {
                     if play.opponent.is_some() {
                         return false;
                     }
-                } else if !self.all_protected() {
-                    if play.opponent.is_none() {
-                        return false;
-                    }
+                } else if !self.all_protected() && play.opponent.is_none() {
+                    return false;
                 }
 
                 if !play.card.needs_guess() {
                     if play.guess.is_some() {
                         return false;
                     }
-                } else if !self.all_protected() {
-                    if play.guess.is_none() {
-                        return false;
-                    }
+                } else if !self.all_protected() && play.guess.is_none() {
+                    return false;
                 }
 
                 if let Some(op) = play.opponent {
@@ -170,7 +148,7 @@ impl<'a> GameState<'a> {
         }
     }
 
-    fn active_players(&self) -> HashSet<PlayerId> {
+    pub fn active_players(&self) -> HashSet<PlayerId> {
         self.players
             .iter()
             .enumerate()
@@ -179,7 +157,7 @@ impl<'a> GameState<'a> {
             .collect()
     }
 
-    fn other_players(&self) -> HashSet<PlayerId> {
+    pub fn other_players(&self) -> HashSet<PlayerId> {
         self.players
             .iter()
             .enumerate()
@@ -188,178 +166,22 @@ impl<'a> GameState<'a> {
             .collect()
     }
 
-    fn other_active_players(&self) -> HashSet<PlayerId> {
+    pub fn other_active_players(&self) -> HashSet<PlayerId> {
         self.other_players()
             .intersection(&self.active_players())
             .cloned()
             .collect::<HashSet<_>>()
     }
 
-    fn all_protected(&self) -> bool {
+    pub fn all_protected(&self) -> bool {
         self.other_active_players()
             .iter()
             .all(|&id| self.players[id].protected())
     }
 
-    fn game_over(&self) -> bool {
+    pub fn game_over(&self) -> bool {
         // last card is ussually not used
         self.deck.len() - self.deck_head <= 1 || self.active_players().len() <= 1
-    }
-
-    fn pick_up_card(&mut self, player_id: PlayerId, log: &mut Vec<EventEntry>) {
-        let next_card = self.deck[self.deck_head];
-        self.deck_head += 1;
-        log.push(EventEntry {
-            visibility: EventVisibility::Private(player_id),
-            event: Event::PickUp(
-                player_id,
-                Some(next_card.clone()),
-                self.deck.len() - self.deck_head,
-            ),
-        });
-        self.players[player_id].hand_mut().push(next_card);
-    }
-
-    fn drop_player(&mut self, player_id: PlayerId, reason: &str, log: &mut Vec<EventEntry>) {
-        while let Some(op_card) = self.players[player_id].hand_mut().pop() {
-            log.push(EventEntry {
-                visibility: EventVisibility::Public,
-                event: Event::Fold(player_id, op_card, reason.to_string()),
-            });
-        }
-        log.push(EventEntry {
-            visibility: EventVisibility::Public,
-            event: Event::DropOut(player_id),
-        });
-    }
-
-    fn next_player_turn(&mut self, log: &mut Vec<EventEntry>) {
-        self.players_turn = (self.players_turn + 1) % self.players.len();
-        while !self.players[self.players_turn].is_active() {
-            self.players_turn = (self.players_turn + 1) % self.players.len();
-        }
-        if !self.game_over() {
-            self.pick_up_card(self.players_turn, log);
-        } else {
-            self.wrap_up_round(log);
-        }
-    }
-
-    fn wrap_up_round(&mut self, log: &mut Vec<EventEntry>) {
-        let mut best_players: Vec<PlayerId> = vec![];
-        let mut best_card: Option<Card> = None;
-        for (i, p) in self.players.iter().enumerate() {
-            if let Some(player_card) = p.hand().get(0) {
-                log.push(EventEntry {
-                    visibility: EventVisibility::Public,
-                    event: Event::Fold(i, player_card.clone(), "game is finished".to_string()),
-                });
-                if let Some(card) = best_card {
-                    if card < *player_card {
-                        best_players = vec![i];
-                        best_card = Some(player_card.clone());
-                    } else if card == *player_card {
-                        best_players.push(i);
-                    }
-                } else {
-                    best_players = vec![i];
-                    best_card = Some(player_card.clone());
-                }
-            }
-        }
-
-        log.push(EventEntry {
-            visibility: EventVisibility::Public,
-            event: Event::Winner(best_players),
-        });
-
-        for e in log {
-            e.visibility = EventVisibility::Public;
-        }
-    }
-
-    fn handle_play(&mut self, p: &Play, log: &mut Vec<EventEntry>) {
-        let card = self.players[self.players_turn]
-            .hand_mut()
-            .remove_first_where(|&card| card == p.card)
-            .unwrap();
-
-        log.push(EventEntry {
-            visibility: EventVisibility::Public,
-            event: Event::Play(self.players_turn, p.clone()),
-        });
-        if let Some(opponent) = p.opponent {
-            // do not attack protected player
-            if self.players[opponent].protected() && !self.all_protected() {
-                self.drop_player(self.players_turn, "attacked a protected player", log);
-                return;
-            }
-        }
-        self.players[self.players_turn].set_protected(false);
-        match card {
-            Card::Guard => {
-                if let Some(op) = p.opponent {
-                    let g = p.guess.unwrap();
-                    if self.players[op].hand()[0] == g {
-                        self.drop_player(op, "opponent guessed the hand card", log)
-                    }
-                }
-            }
-            Card::Priest => {
-                if let Some(op) = p.opponent {
-                    log.push(EventEntry {
-                        visibility: EventVisibility::Private(self.players_turn),
-                        event: Event::LearnedCard(op, Some(self.players[op].hand()[0].clone())),
-                    });
-                }
-            }
-            Card::Baron => {
-                if let Some(op) = p.opponent {
-                    let op_card = self.players[op].hand()[0];
-                    let player_card = self.players[self.players_turn].hand()[0];
-                    if op_card < player_card {
-                        self.drop_player(op, "smaller card then opponent", log);
-                    } else if player_card < op_card {
-                        self.drop_player(self.players_turn, "smaller card then opponent", log);
-                    }
-                }
-            }
-            Card::Maid => {
-                self.players[self.players_turn].set_protected(true);
-            }
-            Card::Prince => {
-                if let Some(op) = p.opponent {
-                    if self.players[op].hand()[0] == Card::Princess {
-                        self.drop_player(op, "forced to play the princess", log);
-                    } else {
-                        let folded = self.players[op].hand_mut().pop().unwrap();
-                        log.push(EventEntry {
-                            visibility: EventVisibility::Public,
-                            event: Event::Fold(
-                                op,
-                                folded,
-                                "opponent has played prince to force it".to_string(),
-                            ),
-                        });
-                        self.pick_up_card(op, log);
-                    }
-                }
-            }
-            Card::King => {
-                if let Some(op) = p.opponent {
-                    let op_card = self.players[op].hand_mut().pop().unwrap();
-                    let player_card = self.players[self.players_turn].hand_mut().pop().unwrap();
-                    self.players[op].hand_mut().push(player_card);
-                    self.players[self.players_turn].hand_mut().push(op_card);
-                }
-            }
-            Card::Countess => {}
-            Card::Princess => self.drop_player(
-                self.players_turn,
-                "playing the princess is equivalent to giving up",
-                log,
-            ),
-        }
     }
 }
 

--- a/royals_core/src/game_state.rs
+++ b/royals_core/src/game_state.rs
@@ -1,61 +1,158 @@
+use itertools::Itertools;
 use std::collections::HashSet;
 
-use crate::{card::Card, event::EventEntry, player::PlayerId};
+use crate::{
+    card::Card,
+    event::{Event, EventEntry, EventVisibility},
+    play::{Action, ActionId, Play},
+    player::PlayerId,
+    utils::VecExtensions,
+};
 
-pub struct PlayerState {
+struct PlayerState {
     protected: bool,
     hand: Vec<Card>,
 }
+
 impl PlayerState {
-    pub fn new() -> Self {
+    fn new() -> Self {
         PlayerState {
             protected: false,
             hand: vec![],
         }
     }
-    pub fn protected(&self) -> bool {
+    fn protected(&self) -> bool {
         self.protected.clone()
     }
 
-    pub fn set_protected(&mut self, value: bool) {
+    fn set_protected(&mut self, value: bool) {
         self.protected = value;
     }
 
-    pub fn hand(&self) -> &Vec<Card> {
+    fn hand(&self) -> &Vec<Card> {
         &self.hand
     }
 
-    pub fn hand_mut(&mut self) -> &mut Vec<Card> {
+    fn hand_mut(&mut self) -> &mut Vec<Card> {
         &mut self.hand
     }
 
-    pub fn is_active(&self) -> bool {
+    fn is_active(&self) -> bool {
         !&self.hand().is_empty()
     }
 }
 
 pub struct GameState {
-    pub players: Vec<PlayerState>,
-    pub game_log: Vec<EventEntry>,
-    pub deck_head: usize,
-    pub players_turn: PlayerId,
+    players: Vec<PlayerState>,
+    deck_head: usize,
+    players_turn: PlayerId,
+    game_over: bool,
 }
 
 impl GameState {
-    pub fn new(player_count: usize) -> Self {
+    pub fn new(player_count: usize, deck: &[Card], log: &mut Vec<EventEntry>) -> Self {
         let mut state = GameState {
             players: vec![],
-            game_log: vec![],
             deck_head: 0,
             players_turn: 0,
+            game_over: false,
         };
-        for _i in 0..player_count {
+        for i in 0..player_count {
             state.players.push(PlayerState::new());
+            state.pick_up_card(i, &deck, log);
         }
+        state.pick_up_card(state.players_turn, &deck, log);
         state
     }
 
-    pub fn active_players(&self) -> HashSet<PlayerId> {
+    pub fn valid_actions(&self) -> (Option<PlayerId>, Vec<Action>) {
+        if self.game_over {
+            return (None, vec![]);
+        }
+        let mut actions = vec![Action::GiveUp];
+        let mut first_card: Option<Card> = None;
+
+        for card in self.players[self.players_turn].hand() {
+            // avoid dublicate entries
+            if first_card.is_none() {
+                first_card = Some(card.clone());
+            } else if first_card.unwrap() == *card {
+                break;
+            }
+
+            actions.push(Action::Play(Play {
+                card: *card,
+                opponent: None,
+                guess: None,
+            }));
+            for opponent in self.other_active_players() {
+                actions.push(Action::Play(Play {
+                    card: *card,
+                    opponent: Some(opponent),
+                    guess: None,
+                }));
+                for guess in Card::guessable() {
+                    actions.push(Action::Play(Play {
+                        card: *card,
+                        opponent: Some(opponent),
+                        guess: Some(*guess),
+                    }));
+                }
+            }
+        }
+        (
+            Some(self.players_turn),
+            actions
+                .into_iter()
+                .filter(|a| self.is_valid(a))
+                .collect_vec(),
+        )
+    }
+
+    pub fn handle_action(&mut self, action: ActionId, deck: &[Card], log: &mut Vec<EventEntry>) {
+        let (_, actions) = self.valid_actions();
+        if action < actions.len() {
+            match &actions[action] {
+                Action::GiveUp => {
+                    self.drop_player(self.players_turn, "Player gave up".to_string(), log);
+                }
+                Action::Play(p) => {
+                    self.handle_play(p, &deck, log);
+                }
+            }
+            self.next_player_turn(&deck, log);
+        }
+    }
+
+    fn wrap_up_round(&mut self, log: &mut Vec<EventEntry>) {
+        let mut best_players: Vec<PlayerId> = vec![];
+        let mut best_card: Option<Card> = None;
+        for (i, p) in self.players.iter().enumerate() {
+            if let Some(player_card) = p.hand().get(0) {
+                log.push(EventEntry {
+                    visibility: EventVisibility::Public,
+                    event: Event::Fold(i, player_card.clone(), "game is finished".to_string()),
+                });
+                if let Some(card) = best_card {
+                    if card < *player_card {
+                        best_players = vec![i];
+                        best_card = Some(player_card.clone());
+                    } else if card == *player_card {
+                        best_players.push(i);
+                    }
+                } else {
+                    best_players = vec![i];
+                    best_card = Some(player_card.clone());
+                }
+            }
+        }
+        log.push(EventEntry {
+            visibility: EventVisibility::Public,
+            event: Event::Winner(best_players),
+        });
+    }
+
+    fn active_players(&self) -> HashSet<PlayerId> {
         self.players
             .iter()
             .enumerate()
@@ -73,17 +170,201 @@ impl GameState {
             .collect()
     }
 
-    pub fn other_active_players(&self) -> HashSet<PlayerId> {
+    fn other_active_players(&self) -> HashSet<PlayerId> {
         self.other_players()
             .intersection(&self.active_players())
             .cloned()
             .collect::<HashSet<_>>()
     }
 
-    pub fn all_protected(&self) -> bool {
+    fn all_protected(&self) -> bool {
         self.other_active_players()
             .iter()
             .all(|&id| self.players[id].protected())
+    }
+
+    fn pick_up_card(&mut self, player_id: PlayerId, deck: &[Card], log: &mut Vec<EventEntry>) {
+        let next_card = deck[self.deck_head];
+        self.deck_head += 1;
+        log.push(EventEntry {
+            visibility: EventVisibility::Private(player_id),
+            event: Event::PickUp(
+                player_id,
+                Some(next_card.clone()),
+                deck.len() - self.deck_head,
+            ),
+        });
+        self.players[player_id].hand_mut().push(next_card);
+    }
+
+    fn drop_player(&mut self, player_id: PlayerId, reason: String, log: &mut Vec<EventEntry>) {
+        while let Some(op_card) = self.players[player_id].hand_mut().pop() {
+            log.push(EventEntry {
+                visibility: EventVisibility::Public,
+                event: Event::Fold(player_id, op_card, reason.clone()),
+            });
+        }
+        log.push(EventEntry {
+            visibility: EventVisibility::Public,
+            event: Event::DropOut(player_id),
+        });
+    }
+
+    fn next_player_turn(&mut self, deck: &[Card], log: &mut Vec<EventEntry>) {
+        self.players_turn = (self.players_turn + 1) % self.players.len();
+        while !self.players[self.players_turn].is_active() {
+            self.players_turn = (self.players_turn + 1) % self.players.len();
+        }
+        // last card is ussually not used
+        self.game_over = !(deck.len() - self.deck_head > 1 && self.active_players().len() > 1);
+        if !self.game_over {
+            self.pick_up_card(self.players_turn, &deck, log);
+        } else {
+            self.wrap_up_round(log);
+        }
+    }
+
+    fn is_valid(&self, action: &Action) -> bool {
+        match action {
+            Action::GiveUp => true,
+            Action::Play(play) => {
+                if !self.players[self.players_turn].hand().contains(&play.card) {
+                    return false;
+                }
+                if self.players[self.players_turn]
+                    .hand()
+                    .contains(&Card::Countess)
+                {
+                    if play.card == Card::Prince || play.card == Card::King {
+                        return false;
+                    }
+                }
+                if !play.card.needs_opponent() {
+                    if play.opponent.is_some() {
+                        return false;
+                    }
+                } else if !self.all_protected() {
+                    if play.opponent.is_none() {
+                        return false;
+                    }
+                }
+
+                if !play.card.needs_guess() {
+                    if play.guess.is_some() {
+                        return false;
+                    }
+                } else if !self.all_protected() {
+                    if play.guess.is_none() {
+                        return false;
+                    }
+                }
+
+                if let Some(op) = play.opponent {
+                    if op == self.players_turn {
+                        return false;
+                    }
+                    if op >= self.players.len() {
+                        return false;
+                    }
+                    if !self.players[op].is_active() {
+                        return false;
+                    }
+                }
+                true
+            }
+        }
+    }
+
+    fn handle_play(&mut self, p: &Play, deck: &[Card], log: &mut Vec<EventEntry>) {
+        let card = self.players[self.players_turn]
+            .hand_mut()
+            .remove_first_where(|&card| card == p.card)
+            .unwrap();
+
+        log.push(EventEntry {
+            visibility: EventVisibility::Public,
+            event: Event::Play(self.players_turn, p.clone()),
+        });
+        if let Some(opponent) = p.opponent {
+            // do not attack protected player
+            if self.players[opponent].protected() && !self.all_protected() {
+                self.drop_player(
+                    self.players_turn,
+                    "attacked a protected player".to_string(),
+                    log,
+                );
+                return;
+            }
+        }
+        self.players[self.players_turn].set_protected(false);
+        match card {
+            Card::Guard => {
+                if let Some(op) = p.opponent {
+                    let g = p.guess.unwrap();
+                    if self.players[op].hand()[0] == g {
+                        self.drop_player(op, "opponent guessed the hand card".to_string(), log)
+                    }
+                }
+            }
+            Card::Priest => {
+                if let Some(op) = p.opponent {
+                    log.push(EventEntry {
+                        visibility: EventVisibility::Private(self.players_turn),
+                        event: Event::LearnedCard(op, Some(self.players[op].hand()[0].clone())),
+                    });
+                }
+            }
+            Card::Baron => {
+                if let Some(op) = p.opponent {
+                    let op_card = self.players[op].hand()[0];
+                    let player_card = self.players[self.players_turn].hand()[0];
+                    if op_card < player_card {
+                        self.drop_player(op, "smaller card then opponent".to_string(), log);
+                    } else if player_card < op_card {
+                        self.drop_player(
+                            self.players_turn,
+                            "smaller card then opponent".to_string(),
+                            log,
+                        );
+                    }
+                }
+            }
+            Card::Maid => {
+                self.players[self.players_turn].set_protected(true);
+            }
+            Card::Prince => {
+                if let Some(op) = p.opponent {
+                    if self.players[op].hand()[0] == Card::Princess {
+                        self.drop_player(op, "forced to play the princess".to_string(), log);
+                    } else {
+                        let folded = self.players[op].hand_mut().pop().unwrap();
+                        log.push(EventEntry {
+                            visibility: EventVisibility::Public,
+                            event: Event::Fold(
+                                op,
+                                folded,
+                                "opponent has played prince to force it".to_string(),
+                            ),
+                        });
+                        self.pick_up_card(op, deck, log);
+                    }
+                }
+            }
+            Card::King => {
+                if let Some(op) = p.opponent {
+                    let op_card = self.players[op].hand_mut().pop().unwrap();
+                    let player_card = self.players[self.players_turn].hand_mut().pop().unwrap();
+                    self.players[op].hand_mut().push(player_card);
+                    self.players[self.players_turn].hand_mut().push(op_card);
+                }
+            }
+            Card::Countess => {}
+            Card::Princess => self.drop_player(
+                self.players_turn,
+                "playing the princess is equivalent to giving up".to_string(),
+                log,
+            ),
+        }
     }
 }
 
@@ -106,9 +387,9 @@ mod tests {
                     hand: vec![Card::King],
                 },
             ],
-            game_log: vec![],
             deck_head: 0,
             players_turn: 0,
+            game_over: false,
         };
 
         assert_eq!(state.active_players(), HashSet::from([1]));
@@ -131,9 +412,9 @@ mod tests {
                     hand: vec![],
                 },
             ],
-            game_log: vec![],
             deck_head: 0,
             players_turn: 1, // second player turn
+            game_over: false,
         };
 
         assert_eq!(state.other_players(), HashSet::from([0, 2]));
@@ -156,9 +437,9 @@ mod tests {
                     hand: vec![Card::Countess],
                 }, // protected
             ],
-            game_log: vec![],
             deck_head: 0,
             players_turn: 1, // second players turn
+            game_over: false,
         };
 
         assert_eq!(state.all_protected(), true);
@@ -185,9 +466,9 @@ mod tests {
                     hand: vec![Card::Guard],
                 }, // unprotected
             ],
-            game_log: vec![],
             deck_head: 0,
             players_turn: 1, // second players turn
+            game_over: false,
         };
 
         assert_eq!(state.all_protected(), false);

--- a/royals_core/src/game_state.rs
+++ b/royals_core/src/game_state.rs
@@ -146,10 +146,15 @@ impl GameState {
                 }
             }
         }
+
         log.push(EventEntry {
             visibility: EventVisibility::Public,
             event: Event::Winner(best_players),
         });
+
+        for e in log {
+            e.visibility = EventVisibility::Public;
+        }
     }
 
     fn active_players(&self) -> HashSet<PlayerId> {

--- a/royals_core/src/game_state.rs
+++ b/royals_core/src/game_state.rs
@@ -44,7 +44,7 @@ impl PlayerState {
 
 pub struct GameState<'a> {
     pub players: Vec<PlayerState>,
-    pub deck_head: usize,
+    pub played_card_count: usize,
     pub players_turn: PlayerId,
     pub deck: &'a [Card],
 }
@@ -53,7 +53,7 @@ impl<'a> GameState<'a> {
     pub fn new(player_count: usize, deck: &'a [Card], log: &mut Vec<EventEntry>) -> Self {
         let mut state = GameState {
             players: vec![],
-            deck_head: 0,
+            played_card_count: 0,
             players_turn: 0,
             deck,
         };
@@ -181,7 +181,7 @@ impl<'a> GameState<'a> {
 
     pub fn game_over(&self) -> bool {
         // last card is ussually not used
-        self.deck.len() - self.deck_head <= 1 || self.active_players().len() <= 1
+        self.deck.len() - self.played_card_count <= 1 || self.active_players().len() <= 1
     }
 }
 
@@ -206,7 +206,7 @@ mod tests {
                     hand: vec![Card::King],
                 },
             ],
-            deck_head: 0,
+            played_card_count: 0,
             players_turn: 0,
         };
 
@@ -232,7 +232,7 @@ mod tests {
                     hand: vec![],
                 },
             ],
-            deck_head: 0,
+            played_card_count: 0,
             players_turn: 1, // second player turn
         };
 
@@ -258,7 +258,7 @@ mod tests {
                     hand: vec![Card::Countess],
                 }, // protected
             ],
-            deck_head: 0,
+            played_card_count: 0,
             players_turn: 1, // second players turn
         };
 
@@ -288,7 +288,7 @@ mod tests {
                     hand: vec![Card::Guard],
                 }, // unprotected
             ],
-            deck_head: 0,
+            played_card_count: 0,
             players_turn: 1, // second players turn
         };
 

--- a/royals_core/src/game_state.rs
+++ b/royals_core/src/game_state.rs
@@ -1,5 +1,6 @@
-use itertools::Itertools;
-use std::collections::HashSet;
+use itertools::{iproduct, Itertools};
+use std::{collections::HashSet, iter::once};
+use strum::IntoEnumIterator;
 
 use crate::{
     card::Card,
@@ -47,11 +48,11 @@ pub struct GameState<'a> {
     deck_head: usize,
     players_turn: PlayerId,
     game_over: bool,
-    deck: &'a[Card],
+    deck: &'a [Card],
 }
 
-impl <'a>GameState<'a> {
-    pub fn new(player_count: usize, deck: &'a[Card], log: &mut Vec<EventEntry>) -> Self {
+impl<'a> GameState<'a> {
+    pub fn new(player_count: usize, deck: &'a [Card], log: &mut Vec<EventEntry>) -> Self {
         let mut state = GameState {
             players: vec![],
             deck_head: 0,
@@ -67,56 +68,12 @@ impl <'a>GameState<'a> {
         state
     }
 
-    pub fn valid_actions(&self) -> (Option<PlayerId>, Vec<Action>) {
-        if self.game_over {
-            return (None, vec![]);
-        }
-        let mut actions = vec![Action::GiveUp];
-        let mut first_card: Option<Card> = None;
-
-        for card in self.players[self.players_turn].hand() {
-            // avoid dublicate entries
-            if first_card.is_none() {
-                first_card = Some(card.clone());
-            } else if first_card.unwrap() == *card {
-                break;
-            }
-
-            actions.push(Action::Play(Play {
-                card: *card,
-                opponent: None,
-                guess: None,
-            }));
-            for opponent in self.other_active_players() {
-                actions.push(Action::Play(Play {
-                    card: *card,
-                    opponent: Some(opponent),
-                    guess: None,
-                }));
-                for guess in Card::guessable() {
-                    actions.push(Action::Play(Play {
-                        card: *card,
-                        opponent: Some(opponent),
-                        guess: Some(*guess),
-                    }));
-                }
-            }
-        }
-        (
-            Some(self.players_turn),
-            actions
-                .into_iter()
-                .filter(|a| self.is_valid(a))
-                .collect_vec(),
-        )
-    }
-
     pub fn handle_action(&mut self, action: ActionId, log: &mut Vec<EventEntry>) {
         let (_, actions) = self.valid_actions();
         if action < actions.len() {
             match &actions[action] {
                 Action::GiveUp => {
-                    self.drop_player(self.players_turn, "Player gave up".to_string(), log);
+                    self.drop_player(self.players_turn, "Player gave up", log);
                 }
                 Action::Play(p) => {
                     self.handle_play(p, log);
@@ -126,112 +83,45 @@ impl <'a>GameState<'a> {
         }
     }
 
-    fn wrap_up_round(&mut self, log: &mut Vec<EventEntry>) {
-        let mut best_players: Vec<PlayerId> = vec![];
-        let mut best_card: Option<Card> = None;
-        for (i, p) in self.players.iter().enumerate() {
-            if let Some(player_card) = p.hand().get(0) {
-                log.push(EventEntry {
-                    visibility: EventVisibility::Public,
-                    event: Event::Fold(i, player_card.clone(), "game is finished".to_string()),
-                });
-                if let Some(card) = best_card {
-                    if card < *player_card {
-                        best_players = vec![i];
-                        best_card = Some(player_card.clone());
-                    } else if card == *player_card {
-                        best_players.push(i);
-                    }
-                } else {
-                    best_players = vec![i];
-                    best_card = Some(player_card.clone());
-                }
-            }
-        }
-
-        log.push(EventEntry {
-            visibility: EventVisibility::Public,
-            event: Event::Winner(best_players),
-        });
-
-        for e in log {
-            e.visibility = EventVisibility::Public;
-        }
+    pub fn valid_actions(&self) -> (Option<PlayerId>, Vec<Action>) {
+        let actions: Vec<Action> = once(Action::GiveUp)
+            .chain(self.possible_actions())
+            .filter(|a| self.is_valid(a))
+            .collect();
+        (
+            if actions.is_empty() {
+                None
+            } else {
+                Some(self.players_turn)
+            },
+            actions,
+        )
     }
 
-    fn active_players(&self) -> HashSet<PlayerId> {
-        self.players
-            .iter()
-            .enumerate()
-            .filter(|&(_, p)| p.is_active())
-            .map(|(i, _)| i)
-            .collect()
-    }
+    fn possible_actions(&self) -> Vec<Action> {
+        // todo is there an alternative way to also iterate over None
+        let others = self.other_active_players();
+        let mut optional_players = others.iter().map(|p| Some(p.clone())).collect_vec();
+        optional_players.push(None);
 
-    fn other_players(&self) -> HashSet<PlayerId> {
-        self.players
-            .iter()
-            .enumerate()
-            .map(|(i, _)| i)
-            .filter(|&id| id != self.players_turn)
-            .collect()
-    }
+        let mut optional_card = Card::iter().map(|c| Some(c)).collect_vec();
+        optional_card.push(None);
 
-    fn other_active_players(&self) -> HashSet<PlayerId> {
-        self.other_players()
-            .intersection(&self.active_players())
-            .cloned()
-            .collect::<HashSet<_>>()
-    }
-
-    fn all_protected(&self) -> bool {
-        self.other_active_players()
-            .iter()
-            .all(|&id| self.players[id].protected())
-    }
-
-    fn pick_up_card(&mut self, player_id: PlayerId, log: &mut Vec<EventEntry>) {
-        let next_card = self.deck[self.deck_head];
-        self.deck_head += 1;
-        log.push(EventEntry {
-            visibility: EventVisibility::Private(player_id),
-            event: Event::PickUp(
-                player_id,
-                Some(next_card.clone()),
-                self.deck.len() - self.deck_head,
-            ),
-        });
-        self.players[player_id].hand_mut().push(next_card);
-    }
-
-    fn drop_player(&mut self, player_id: PlayerId, reason: String, log: &mut Vec<EventEntry>) {
-        while let Some(op_card) = self.players[player_id].hand_mut().pop() {
-            log.push(EventEntry {
-                visibility: EventVisibility::Public,
-                event: Event::Fold(player_id, op_card, reason.clone()),
-            });
-        }
-        log.push(EventEntry {
-            visibility: EventVisibility::Public,
-            event: Event::DropOut(player_id),
-        });
-    }
-
-    fn next_player_turn(&mut self, log: &mut Vec<EventEntry>) {
-        self.players_turn = (self.players_turn + 1) % self.players.len();
-        while !self.players[self.players_turn].is_active() {
-            self.players_turn = (self.players_turn + 1) % self.players.len();
-        }
-        // last card is ussually not used
-        self.game_over = !(self.deck.len() - self.deck_head > 1 && self.active_players().len() > 1);
-        if !self.game_over {
-            self.pick_up_card(self.players_turn, log);
-        } else {
-            self.wrap_up_round(log);
-        }
+        iproduct!(Card::iter(), optional_players.iter(), optional_card.iter())
+            .map(|(card, &opponent, &guess)| {
+                Action::Play(Play {
+                    card,
+                    opponent,
+                    guess,
+                })
+            })
+            .collect_vec()
     }
 
     fn is_valid(&self, action: &Action) -> bool {
+        if self.game_over {
+            return false;
+        }
         match action {
             Action::GiveUp => true,
             Action::Play(play) => {
@@ -282,6 +172,111 @@ impl <'a>GameState<'a> {
         }
     }
 
+    fn active_players(&self) -> HashSet<PlayerId> {
+        self.players
+            .iter()
+            .enumerate()
+            .filter(|&(_, p)| p.is_active())
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    fn other_players(&self) -> HashSet<PlayerId> {
+        self.players
+            .iter()
+            .enumerate()
+            .map(|(i, _)| i)
+            .filter(|&id| id != self.players_turn)
+            .collect()
+    }
+
+    fn other_active_players(&self) -> HashSet<PlayerId> {
+        self.other_players()
+            .intersection(&self.active_players())
+            .cloned()
+            .collect::<HashSet<_>>()
+    }
+
+    fn all_protected(&self) -> bool {
+        self.other_active_players()
+            .iter()
+            .all(|&id| self.players[id].protected())
+    }
+
+    fn pick_up_card(&mut self, player_id: PlayerId, log: &mut Vec<EventEntry>) {
+        let next_card = self.deck[self.deck_head];
+        self.deck_head += 1;
+        log.push(EventEntry {
+            visibility: EventVisibility::Private(player_id),
+            event: Event::PickUp(
+                player_id,
+                Some(next_card.clone()),
+                self.deck.len() - self.deck_head,
+            ),
+        });
+        self.players[player_id].hand_mut().push(next_card);
+    }
+
+    fn drop_player(&mut self, player_id: PlayerId, reason: &str, log: &mut Vec<EventEntry>) {
+        while let Some(op_card) = self.players[player_id].hand_mut().pop() {
+            log.push(EventEntry {
+                visibility: EventVisibility::Public,
+                event: Event::Fold(player_id, op_card, reason.to_string()),
+            });
+        }
+        log.push(EventEntry {
+            visibility: EventVisibility::Public,
+            event: Event::DropOut(player_id),
+        });
+    }
+
+    fn next_player_turn(&mut self, log: &mut Vec<EventEntry>) {
+        self.players_turn = (self.players_turn + 1) % self.players.len();
+        while !self.players[self.players_turn].is_active() {
+            self.players_turn = (self.players_turn + 1) % self.players.len();
+        }
+        // last card is ussually not used
+        self.game_over = !(self.deck.len() - self.deck_head > 1 && self.active_players().len() > 1);
+        if !self.game_over {
+            self.pick_up_card(self.players_turn, log);
+        } else {
+            self.wrap_up_round(log);
+        }
+    }
+
+    fn wrap_up_round(&mut self, log: &mut Vec<EventEntry>) {
+        let mut best_players: Vec<PlayerId> = vec![];
+        let mut best_card: Option<Card> = None;
+        for (i, p) in self.players.iter().enumerate() {
+            if let Some(player_card) = p.hand().get(0) {
+                log.push(EventEntry {
+                    visibility: EventVisibility::Public,
+                    event: Event::Fold(i, player_card.clone(), "game is finished".to_string()),
+                });
+                if let Some(card) = best_card {
+                    if card < *player_card {
+                        best_players = vec![i];
+                        best_card = Some(player_card.clone());
+                    } else if card == *player_card {
+                        best_players.push(i);
+                    }
+                } else {
+                    best_players = vec![i];
+                    best_card = Some(player_card.clone());
+                }
+            }
+        }
+
+        log.push(EventEntry {
+            visibility: EventVisibility::Public,
+            event: Event::Winner(best_players),
+        });
+
+        for e in log {
+            e.visibility = EventVisibility::Public;
+        }
+    }
+
     fn handle_play(&mut self, p: &Play, log: &mut Vec<EventEntry>) {
         let card = self.players[self.players_turn]
             .hand_mut()
@@ -295,11 +290,7 @@ impl <'a>GameState<'a> {
         if let Some(opponent) = p.opponent {
             // do not attack protected player
             if self.players[opponent].protected() && !self.all_protected() {
-                self.drop_player(
-                    self.players_turn,
-                    "attacked a protected player".to_string(),
-                    log,
-                );
+                self.drop_player(self.players_turn, "attacked a protected player", log);
                 return;
             }
         }
@@ -309,7 +300,7 @@ impl <'a>GameState<'a> {
                 if let Some(op) = p.opponent {
                     let g = p.guess.unwrap();
                     if self.players[op].hand()[0] == g {
-                        self.drop_player(op, "opponent guessed the hand card".to_string(), log)
+                        self.drop_player(op, "opponent guessed the hand card", log)
                     }
                 }
             }
@@ -326,13 +317,9 @@ impl <'a>GameState<'a> {
                     let op_card = self.players[op].hand()[0];
                     let player_card = self.players[self.players_turn].hand()[0];
                     if op_card < player_card {
-                        self.drop_player(op, "smaller card then opponent".to_string(), log);
+                        self.drop_player(op, "smaller card then opponent", log);
                     } else if player_card < op_card {
-                        self.drop_player(
-                            self.players_turn,
-                            "smaller card then opponent".to_string(),
-                            log,
-                        );
+                        self.drop_player(self.players_turn, "smaller card then opponent", log);
                     }
                 }
             }
@@ -342,7 +329,7 @@ impl <'a>GameState<'a> {
             Card::Prince => {
                 if let Some(op) = p.opponent {
                     if self.players[op].hand()[0] == Card::Princess {
-                        self.drop_player(op, "forced to play the princess".to_string(), log);
+                        self.drop_player(op, "forced to play the princess", log);
                     } else {
                         let folded = self.players[op].hand_mut().pop().unwrap();
                         log.push(EventEntry {
@@ -368,7 +355,7 @@ impl <'a>GameState<'a> {
             Card::Countess => {}
             Card::Princess => self.drop_player(
                 self.players_turn,
-                "playing the princess is equivalent to giving up".to_string(),
+                "playing the princess is equivalent to giving up",
                 log,
             ),
         }

--- a/royals_core/src/game_state.rs
+++ b/royals_core/src/game_state.rs
@@ -1,78 +1,58 @@
 use std::collections::HashSet;
 
-use rand::seq::SliceRandom;
+use crate::{card::Card, event::EventEntry, player::PlayerId};
 
-use crate::{
-    card::Card,
-    event::EventEntry,
-    player::{Player, PlayerId},
-    random_playing_computer::RandomPlayingComputer,
-};
+pub struct PlayerState {
+    protected: bool,
+    hand: Vec<Card>,
+}
+impl PlayerState {
+    pub fn new() -> Self {
+        PlayerState {
+            protected: false,
+            hand: vec![],
+        }
+    }
+    pub fn protected(&self) -> bool {
+        self.protected.clone()
+    }
+
+    pub fn set_protected(&mut self, value: bool) {
+        self.protected = value;
+    }
+
+    pub fn hand(&self) -> &Vec<Card> {
+        &self.hand
+    }
+
+    pub fn hand_mut(&mut self) -> &mut Vec<Card> {
+        &mut self.hand
+    }
+
+    pub fn is_active(&self) -> bool {
+        !&self.hand().is_empty()
+    }
+}
 
 pub struct GameState {
-    pub deck: Vec<Card>,
-    pub players: Vec<Box<dyn Player>>,
+    pub players: Vec<PlayerState>,
     pub game_log: Vec<EventEntry>,
+    pub deck_head: usize,
     pub players_turn: PlayerId,
 }
 
 impl GameState {
-    pub fn new<C, T>(player_constructor: C) -> Self
-    where
-        C: FnOnce() -> T,
-        T: Player + 'static,
-    {
+    pub fn new(player_count: usize) -> Self {
         let mut state = GameState {
-            deck: vec![
-                Card::Guard,
-                Card::Guard,
-                Card::Guard,
-                Card::Guard,
-                Card::Guard,
-                Card::Priest,
-                Card::Priest,
-                Card::Baron,
-                Card::Baron,
-                Card::Maid,
-                Card::Maid,
-                Card::Prince,
-                Card::Prince,
-                Card::King,
-                Card::Countess,
-                Card::Princess,
-            ],
             players: vec![],
             game_log: vec![],
+            deck_head: 0,
             players_turn: 0,
         };
-
-        state.add_player(player_constructor);
-        state.add_player(RandomPlayingComputer::new);
-        state.add_player(RandomPlayingComputer::new);
-        state.add_player(RandomPlayingComputer::new);
-
-        //state.players.shuffle(&mut rand::thread_rng()); todo
-
-        state.deck.shuffle(&mut rand::thread_rng());
-
-        for i in 0..state.players.len() {
-            state.pick_up_card(i);
+        for _i in 0..player_count {
+            state.players.push(PlayerState::new());
         }
-
         state
-    }
-
-    fn add_player<C, T>(&mut self, player_constructor: C)
-    where
-        C: FnOnce() -> T,
-        T: Player + 'static,
-    {
-        let player = player_constructor();
-        self.players.push(Box::new(player));
-    }
-
-    pub fn player_names(&self) -> Vec<&String> {
-        self.players.iter().map(|p| p.name()).collect::<Vec<_>>()
     }
 
     pub fn active_players(&self) -> HashSet<PlayerId> {
@@ -111,38 +91,23 @@ impl GameState {
 mod tests {
     use std::collections::HashSet;
 
-    use crate::{
-        card::Card,
-        event::Event,
-        game_state::GameState,
-        play::Action,
-        player::{Player, PlayerData, PlayerId},
-    };
-
-    #[test]
-    fn player_names_should_return_list_of_names() {
-        let state = GameState {
-            deck: vec![],
-            players: vec![
-                Box::new(TestPlayer::new(0, "Foo", false, vec![])),
-                Box::new(TestPlayer::new(1, "Bar", false, vec![])),
-            ],
-            game_log: vec![],
-            players_turn: 0,
-        };
-
-        assert_eq!(state.player_names(), vec!["Foo", "Bar"]);
-    }
+    use crate::{card::Card, game_state::GameState, game_state::PlayerState};
 
     #[test]
     fn active_players_should_return_player_ids_with_non_empty_hand() {
         let state = GameState {
-            deck: vec![],
             players: vec![
-                Box::new(TestPlayer::new(0, "Foo", false, vec![])),
-                Box::new(TestPlayer::new(1, "Bar", false, vec![Card::King])),
+                PlayerState {
+                    protected: false,
+                    hand: vec![],
+                },
+                PlayerState {
+                    protected: false,
+                    hand: vec![Card::King],
+                },
             ],
             game_log: vec![],
+            deck_head: 0,
             players_turn: 0,
         };
 
@@ -152,14 +117,23 @@ mod tests {
     #[test]
     fn other_players_should_return_ids_of_others() {
         let state = GameState {
-            deck: vec![],
             players: vec![
-                Box::new(TestPlayer::new(0, "Foo", false, vec![])),
-                Box::new(TestPlayer::new(1, "Bar", false, vec![])),
-                Box::new(TestPlayer::new(2, "Baz", false, vec![])),
+                PlayerState {
+                    protected: false,
+                    hand: vec![],
+                },
+                PlayerState {
+                    protected: false,
+                    hand: vec![],
+                },
+                PlayerState {
+                    protected: false,
+                    hand: vec![],
+                },
             ],
             game_log: vec![],
-            players_turn: 1, // Baz's turn
+            deck_head: 0,
+            players_turn: 1, // second player turn
         };
 
         assert_eq!(state.other_players(), HashSet::from([0, 2]));
@@ -168,14 +142,23 @@ mod tests {
     #[test]
     fn all_protected_should_return_true_if_no_other_active_player_is_unprotected() {
         let state = GameState {
-            deck: vec![],
             players: vec![
-                Box::new(TestPlayer::new(0, "Foo", false, vec![])), // inactive
-                Box::new(TestPlayer::new(1, "Baz", false, vec![Card::King])), // Baz' turn
-                Box::new(TestPlayer::new(2, "Bar", true, vec![])),  // protected
+                PlayerState {
+                    protected: false,
+                    hand: vec![],
+                }, // inactive
+                PlayerState {
+                    protected: false,
+                    hand: vec![Card::King],
+                }, // players turn
+                PlayerState {
+                    protected: true,
+                    hand: vec![Card::Countess],
+                }, // protected
             ],
             game_log: vec![],
-            players_turn: 1, // Baz' turn
+            deck_head: 0,
+            players_turn: 1, // second players turn
         };
 
         assert_eq!(state.all_protected(), true);
@@ -184,57 +167,29 @@ mod tests {
     #[test]
     fn all_protected_should_return_false_if_at_least_one_other_active_player_is_unprotected() {
         let state = GameState {
-            deck: vec![],
             players: vec![
-                Box::new(TestPlayer::new(0, "Foo", false, vec![])), // inactive
-                Box::new(TestPlayer::new(1, "Baz", false, vec![Card::King])), // Baz' turn
-                Box::new(TestPlayer::new(2, "Bar", true, vec![])),  // protected
-                Box::new(TestPlayer::new(3, "Qux", false, vec![Card::Guard])), // unprotected
+                PlayerState {
+                    protected: false,
+                    hand: vec![],
+                }, // inactive
+                PlayerState {
+                    protected: false,
+                    hand: vec![Card::King],
+                }, // players turn
+                PlayerState {
+                    protected: true,
+                    hand: vec![Card::Countess],
+                }, // protected
+                PlayerState {
+                    protected: false,
+                    hand: vec![Card::Guard],
+                }, // unprotected
             ],
             game_log: vec![],
-            players_turn: 1, // Baz' turn
+            deck_head: 0,
+            players_turn: 1, // second players turn
         };
 
         assert_eq!(state.all_protected(), false);
-    }
-
-    // Infra ----------------------------------------------------------------
-
-    pub struct TestPlayer {
-        pub data: PlayerData,
-    }
-
-    impl TestPlayer {
-        pub fn new(id: PlayerId, name: &str, protected: bool, hand: Vec<Card>) -> Self {
-            let mut player = TestPlayer {
-                data: PlayerData::new(name.to_string()),
-            };
-            player.set_protected(protected);
-            *player.hand_mut() = hand;
-            player
-        }
-    }
-
-    impl Player for TestPlayer {
-        fn data(&self) -> &PlayerData {
-            &self.data
-        }
-
-        fn data_mut(&mut self) -> &mut PlayerData {
-            &mut self.data
-        }
-
-        fn notify(&self, _game_log: &[Event], _players: &[&String]) {
-            todo!()
-        }
-
-        fn obtain_action(
-            &self,
-            _players: &[&String],
-            _game_log: &[Event],
-            _actions: &[Action],
-        ) -> usize {
-            todo!()
-        }
     }
 }

--- a/royals_core/src/lib.rs
+++ b/royals_core/src/lib.rs
@@ -6,7 +6,6 @@ use random_playing_computer::RandomPlayingComputer;
 pub mod card;
 pub mod event;
 mod game_lobby;
-mod game_logic;
 mod game_state;
 pub mod play;
 pub mod player;

--- a/royals_core/src/lib.rs
+++ b/royals_core/src/lib.rs
@@ -1,9 +1,11 @@
 use event::Event;
-use game_state::GameState;
+use game_lobby::GameLobby;
 use player::Player;
+use random_playing_computer::RandomPlayingComputer;
 
 pub mod card;
 pub mod event;
+mod game_lobby;
 mod game_logic;
 mod game_state;
 pub mod play;
@@ -16,6 +18,10 @@ where
     C: FnOnce() -> T,
     T: Player + 'static,
 {
-    let mut game = GameState::new(player_constructor);
-    game.run()
+    let mut lobby = GameLobby::new();
+    lobby.add_player(player_constructor);
+    lobby.add_player(RandomPlayingComputer::new);
+    lobby.add_player(RandomPlayingComputer::new);
+    lobby.add_player(RandomPlayingComputer::new);
+    lobby.play_round();
 }

--- a/royals_core/src/lib.rs
+++ b/royals_core/src/lib.rs
@@ -6,6 +6,7 @@ use random_playing_computer::RandomPlayingComputer;
 pub mod card;
 pub mod event;
 mod game_lobby;
+mod game_logic;
 mod game_state;
 pub mod play;
 pub mod player;

--- a/royals_core/src/play.rs
+++ b/royals_core/src/play.rs
@@ -7,6 +7,8 @@ pub struct Play {
     pub guess: Option<Card>,
 }
 
+pub type ActionId = usize;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Action {
     GiveUp,

--- a/royals_core/src/player.rs
+++ b/royals_core/src/player.rs
@@ -1,20 +1,14 @@
-use crate::{card::Card, play::Action, Event};
+use crate::{play::Action, Event};
 
 pub type PlayerId = usize;
 
 pub struct PlayerData {
     name: String,
-    protected: bool,
-    hand: Vec<Card>,
 }
 
 impl PlayerData {
     pub fn new(name: String) -> Self {
-        PlayerData {
-            name,
-            protected: false,
-            hand: vec![],
-        }
+        PlayerData { name }
     }
 }
 
@@ -25,26 +19,6 @@ pub trait Player {
 
     fn name(&self) -> &String {
         &self.data().name
-    }
-
-    fn protected(&self) -> bool {
-        self.data().protected
-    }
-
-    fn set_protected(&mut self, value: bool) {
-        self.data_mut().protected = value;
-    }
-
-    fn hand(&self) -> &Vec<Card> {
-        &self.data().hand
-    }
-
-    fn hand_mut(&mut self) -> &mut Vec<Card> {
-        &mut self.data_mut().hand
-    }
-
-    fn is_active(&self) -> bool {
-        !&self.hand().is_empty()
     }
 
     fn notify(&self, game_log: &[Event], players: &[&String]);


### PR DESCRIPTION
 Separate Game-state from Lobby information:

- Adds convenience function Card::deck to create a un-shuffled deck
- extracts all "lobby" information from game-state: PlayerInterfaces, Player-meta-data (name), ...
- adds function "play_round" to the game lobby. This enables to do multiple rounds soon.
- deck is immutable ( have a card counter), game-state has immutable ref with managed lifetime
- fixes tests in accordance with the changes
- generates all possible actions with `iproduct` and then filters out the valid ones.

I am not 100% sure what should be `game_state` vs `_logic`. For now all functions mutating state are in logic.